### PR TITLE
Added TokenValidationView to validate token without sharing your secret.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Development
+
+* Added validation view to validate token.
+
 ## Version 2.1
 
 * Switched to using [PyJWT](https://github.com/jpadilla/pyjwt) as the

--- a/README.rst
+++ b/README.rst
@@ -297,6 +297,26 @@ which will delete any tokens from the outstanding list and blacklist that have
 expired.  You should set up a cron job on your server or hosting platform which
 runs this command daily.
 
+
+Validating tokens
+-----------------
+
+To allow others to validate tokens without sharing your secret you can add the
+``TokenValidationView`` to your urls::
+
+  from rest_framework_simplejwt.views import (
+      ...
+      TokenValidationView,
+      ...
+  )
+
+  urlpatterns = [
+      ...
+      url(r'^api/token/validate/$', TokenValidationView.as_view(), name='token_validate'),
+      ...
+  ]
+
+
 Experimental features
 ---------------------
 

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -241,3 +241,8 @@ class RefreshToken(BlacklistMixin, Token):
 class AccessToken(Token):
     token_type = 'access'
     lifetime = api_settings.ACCESS_TOKEN_LIFETIME
+
+
+TOKEN_TYPES = dict(
+    (subcls.token_type, subcls) for subcls in Token.__subclasses__()
+)

--- a/rest_framework_simplejwt/views.py
+++ b/rest_framework_simplejwt/views.py
@@ -58,3 +58,13 @@ class TokenRefreshSlidingView(TokenViewBase):
     serializer_class = serializers.TokenRefreshSlidingSerializer
 
 token_refresh_sliding = TokenRefreshSlidingView.as_view()
+
+
+class TokenValidationView(TokenViewBase):
+    """
+    Takes a token and checks it's validity, returns the token if valid, shows
+    an error if not.
+    """
+    serializer_class = serializers.TokenValidationSerializer
+
+token_validation = TokenValidationView.as_view()

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -12,5 +12,7 @@ urlpatterns = [
     url(r'^token/sliding/$', jwt_views.token_obtain_sliding, name='token_obtain_sliding'),
     url(r'^token/sliding/refresh/$', jwt_views.token_refresh_sliding, name='token_refresh_sliding'),
 
+    url(r'^token/validation/$', jwt_views.token_validation, name='token_validation'),
+
     url(r'^test-view/$', views.test_view, name='test_view'),
 ]


### PR DESCRIPTION
For you to look at.

Not 100% sure myself about how the TOKEN_TYPES dict is constructed, but this was the easiest way, but this should probably be limited to the Tokens actually used in your project; When you don't issue sliding tokens you don't want to validate them either.

Also it would be nicer still if you maybe don't even need to specify the token type, but can read it from the payload however the Token is pretty strict in that it will only validate the it's own. If you have ideas on how this could be done differently I'm open to suggestions :)

