### PR TITLE
Do not verify when creating sliding token on refresh

### DIFF
--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -115,7 +115,7 @@ class TokenRefreshSlidingSerializer(serializers.Serializer):
     token = serializers.CharField()
 
     def validate(self, attrs):
-        token = SlidingToken(attrs['token'])
+        token = SlidingToken(attrs['token'], verify=False)
 
         # Check that the timestamp in the "refresh_exp" claim has not
         # passed


### PR DESCRIPTION
See Issue #21. 

The sliding token refresh serializer should not check the
expiration of the JWT, it should only check the refresh expiration.
This commit disables verification of the token when constructing a
SlidingToken instance in the TokenRefreshSlidingSerializer.

Closes #21