### PR TITLE
Accept SIGNING_KEY as string returning function.

### DIFF
--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -18,16 +18,20 @@ ALLOWED_ALGORITHMS = (
 
 
 class TokenBackend(object):
-    def __init__(self, algorithm, signing_key=None, verifying_key=None):
+    def __init__(self, algorithm, signing_key=None, verifying_key=None, user=None):
         if algorithm not in ALLOWED_ALGORITHMS:
             raise TokenBackendError(format_lazy(_("Unrecognized algorithm type '{}'"), algorithm))
 
+        self.user = user
         self.algorithm = algorithm
-        self.signing_key = signing_key
         if algorithm.startswith('HS'):
             self.verifying_key = signing_key
         else:
             self.verifying_key = verifying_key
+        if callable(signing_key):
+            self.signing_key = str(signing_key(user))
+        else:
+            self.signing_key = signing_key
 
     def encode(self, payload):
         """

--- a/rest_framework_simplejwt/state.py
+++ b/rest_framework_simplejwt/state.py
@@ -7,4 +7,4 @@ from .settings import api_settings
 
 User = get_user_model()
 token_backend = TokenBackend(api_settings.ALGORITHM, api_settings.SIGNING_KEY,
-                             api_settings.VERIFYING_KEY)
+                             api_settings.VERIFYING_KEY, User)


### PR DESCRIPTION
Hello,
I found this issue https://github.com/davesque/django-rest-framework-simplejwt/issues/17 which I would like to solve. I propose these changes to allow for that behaivor. Implementation allows for function to return a string from a function since upstream libraries seem to expect a string.

Would be cool with some feedback, maybe this is stupid I dont know I simply tried to solve a problem I had. 

Cheers