### PR TITLE
Add request to authenticate call

### DIFF
--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -28,6 +28,7 @@ class TokenObtainSerializer(serializers.Serializer):
 
     def validate(self, attrs):
         self.user = authenticate(**{
+            'request': self.context['request'],
             self.username_field: attrs[self.username_field],
             'password': attrs['password'],
         })

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 
@@ -53,7 +53,7 @@ class TestTokenObtainSerializer(TestCase):
         self.assertIn(s.username_field, s.errors)
 
     def test_it_should_not_validate_if_user_not_found(self):
-        s = TokenObtainSerializer(data={
+        s = TokenObtainSerializer(context=MagicMock(), data={
             TokenObtainSerializer.username_field: 'missing',
             'password': 'pass',
         })
@@ -65,7 +65,7 @@ class TestTokenObtainSerializer(TestCase):
         self.user.is_active = False
         self.user.save()
 
-        s = TokenObtainSerializer(data={
+        s = TokenObtainSerializer(context=MagicMock(), data={
             TokenObtainSerializer.username_field: self.username,
             'password': self.password,
         })
@@ -85,7 +85,7 @@ class TestTokenObtainSlidingSerializer(TestCase):
         )
 
     def test_it_should_produce_a_json_web_token_when_valid(self):
-        s = TokenObtainSlidingSerializer(data={
+        s = TokenObtainSlidingSerializer(context=MagicMock(), data={
             TokenObtainSlidingSerializer.username_field: self.username,
             'password': self.password,
         })
@@ -110,7 +110,7 @@ class TestTokenObtainPairSerializer(TestCase):
         )
 
     def test_it_should_produce_a_json_web_token_when_valid(self):
-        s = TokenObtainPairSerializer(data={
+        s = TokenObtainPairSerializer(context=MagicMock(), data={
             TokenObtainPairSerializer.username_field: self.username,
             'password': self.password,
         })


### PR DESCRIPTION
## What is the purpose of this PR
Keep project up-to-date with a [deprecation in 1.11](https://docs.djangoproject.com/en/2.1/releases/1.11/#deprecated-features-1-11) and [removal in 2.1](https://docs.djangoproject.com/en/2.1/releases/2.1/#features-removed-in-2-1).

Django 1.11
`The HttpRequest is now passed to authenticate() which in turn passes it to the authentication backend if it accepts a request argument.`

Django 2.1
`The authenticate() method of authentication backends requires request as the first positional argument.`

## What this PR does?
It sends the request to the serializer as a context and add it to the authenticate call.

## No, seriously, what's the real purpose of this PR?
I just wanted to use this library with [django-axes](https://github.com/jazzband/django-axes), which is not possible without this change :)