### PR TITLE
Disabled the trimming of leading and trailing white spaces in password.

### DIFF
--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -16,6 +16,7 @@ class PasswordField(serializers.CharField):
 
         kwargs['style']['input_type'] = 'password'
         kwargs['write_only'] = True
+        kwargs['trim_whitespace'] = False
 
         super(PasswordField, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
During an implementation, I found that password is considered as a Charfield with its attribute _write_only_ set as _True_ and post [#2525](https://github.com/encode/django-rest-framework/pull/2525) _trim_whitespace_ default to _False_. In result, the login functionality accepts the password with leading and trailing whitespaces without distinguishing it from the actual password. 
Hence, with this change, I reset the trimming of the leading and trailing white spaces in the password.