### PR TITLE
Fix unit tests: Use TransactionTestCase instead of TestCase as base for MigrationTestCase

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,7 +4,7 @@ import contextlib
 
 from django.db import connection
 from django.db.migrations.executor import MigrationExecutor
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from rest_framework.test import APIClient
 from rest_framework_simplejwt.compat import reverse
 from rest_framework_simplejwt.settings import api_settings
@@ -82,7 +82,7 @@ def override_api_settings(**settings):
             pass
 
 
-class MigrationTestCase(TestCase):
+class MigrationTestCase(TransactionTestCase):
     migrate_from = None
     migrate_to = None
 


### PR DESCRIPTION
Fixes issue with unit tests described in #60. I currently get the following output when running unit tests in my environment:
```
================================================================================ test session starts ================================================================================
platform linux -- Python 3.6.5, pytest-3.9.2, py-1.7.0, pluggy-0.8.1
rootdir: /home/adam/PycharmProjects/django-rest-framework-simplejwt, inifile: tox.ini
plugins: django-3.4.3, cov-2.6.0
collected 121 items                                                                                                                                                                 

tests/test_authentication.py .....                                                                                                                                            [  4%]
tests/test_backends.py ...............                                                                                                                                        [ 16%]
tests/test_integration.py .....                                                                                                                                               [ 20%]
tests/test_models.py ....................                                                                                                                                     [ 37%]
tests/test_serializers.py ..................                                                                                                                                  [ 52%]
tests/test_token_blacklist.py ......F                                                                                                                                         [ 57%]
tests/test_tokens.py ..........................                                                                                                                               [ 79%]
tests/test_utils.py .....                                                                                                                                                     [ 83%]
tests/test_views.py ....................                                                                                                                                      [100%]

===================================================================================== FAILURES ======================================================================================
____________________________________________________ TestPopulateJtiHexMigration.test_jti_field_should_contain_uuid_hex_strings _____________________________________________________
tests/test_token_blacklist.py:174: in setUp
    super(TestPopulateJtiHexMigration, self).setUp()
tests/utils.py:95: in setUp
    executor.migrate(self.migrate_from)
../../.pyenv/versions/3.6.5/envs/django-rest-framework-simplejwt/lib/python3.6/site-packages/django/db/migrations/executor.py:121: in migrate
    state = self._migrate_all_backwards(plan, full_plan, fake=fake)
../../.pyenv/versions/3.6.5/envs/django-rest-framework-simplejwt/lib/python3.6/site-packages/django/db/migrations/executor.py:196: in _migrate_all_backwards
    self.unapply_migration(states[migration], migration, fake=fake)
../../.pyenv/versions/3.6.5/envs/django-rest-framework-simplejwt/lib/python3.6/site-packages/django/db/migrations/executor.py:261: in unapply_migration
    with self.connection.schema_editor(atomic=migration.atomic) as schema_editor:
../../.pyenv/versions/3.6.5/envs/django-rest-framework-simplejwt/lib/python3.6/site-packages/django/db/backends/sqlite3/schema.py:25: in __enter__
    'SQLite schema editor cannot be used while foreign key '
E   django.db.utils.NotSupportedError: SQLite schema editor cannot be used while foreign key constraint checks are enabled. Make sure to disable them before entering a transaction.atomic() context because SQLite3 does not support disabling them in the middle of a multi-statement transaction.
======================================================================= 1 failed, 120 passed in 2.21 seconds ========================================================================
```

This fix resolves this issue by using the TransactionTestCase as the base for MigrationTestCase (TransactionTestCase does not use transaction.atomic(), which avoids this issue).