### PR TITLE
Make the jti claim optional as per RFC 7519 Section 4.1.7

### DIFF
--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -97,10 +97,6 @@ class Token(object):
         # claim.  We don't want any zombie tokens walking around.
         self.check_exp()
 
-        # Ensure token id is present
-        if 'jti' not in self.payload:
-            raise TokenError(_('Token has no id'))
-
         self.verify_token_type()
 
     def verify_token_type(self):

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -152,8 +152,8 @@ class TestToken(TestCase):
         t = MyToken()
         del t['jti']
 
-        with self.assertRaises(TokenError):
-            MyToken(str(t))
+        t2 = MyToken(str(t))
+        self.assertEqual(t.payload, t2.payload)
 
     def test_str(self):
         token = MyToken()


### PR DESCRIPTION
[RFC 7519 Section 4.1.7](https://tools.ietf.org/html/rfc7519#section-4.1.7) states that the `jti` claim is optional. It's fine for this library to be opinionated and always include a `jti` on generated tokens, but it should not require the claim to be present when validating tokens. This PR removes that check.

The unit tests on this PR will fail until #61 is merged.