### PR TITLE
Extract TokenUser username from token if claim is present

### DIFF
--- a/rest_framework_simplejwt/models.py
+++ b/rest_framework_simplejwt/models.py
@@ -15,8 +15,6 @@ class TokenUser:
     class instead of a `User` model instance.  Instances of this class act as
     stateless user objects which are backed by validated tokens.
     """
-    username = ''
-
     # User is always active since Simple JWT will never issue a token for an
     # inactive user
     is_active = True
@@ -37,6 +35,10 @@ class TokenUser:
     @cached_property
     def pk(self):
         return self.id
+
+    @cached_property
+    def username(self):
+        return self.token.get('username', '')
 
     @cached_property
     def is_staff(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,12 +10,13 @@ class TestTokenUser(TestCase):
     def setUp(self):
         self.token = AuthToken()
         self.token[api_settings.USER_ID_CLAIM] = 42
+        self.token['username'] = 'deep-thought'
         self.token['some_other_stuff'] = 'arstarst'
 
         self.user = TokenUser(self.token)
 
     def test_username(self):
-        self.assertEqual(self.user.username, '')
+        self.assertEqual(self.user.username, 'deep-thought')
 
     def test_is_active(self):
         self.assertTrue(self.user.is_active)
@@ -103,4 +104,4 @@ class TestTokenUser(TestCase):
         self.assertTrue(self.user.is_authenticated)
 
     def test_get_username(self):
-        self.assertEqual(self.user.get_username(), '')
+        self.assertEqual(self.user.get_username(), 'deep-thought')


### PR DESCRIPTION
Currently the TokenUser's username is hardcoded to an empty string. This change will set the username to be the value of the `username` claim in the JWT, if it is present. (Otherwise just defaults to the empty string, like before).

The unit tests on this PR will fail until #61 is merged.