### PR TITLE
updating urlpatterns doc for new Django url syntax

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,8 +64,8 @@ for Simple JWT's ``TokenObtainPairView`` and ``TokenRefreshView`` views:
 
   urlpatterns = [
       ...
-      url(r'^api/token/$', TokenObtainPairView.as_view(), name='token_obtain_pair'),
-      url(r'^api/token/refresh/$', TokenRefreshView.as_view(), name='token_refresh'),
+      path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+      path('api/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
       ...
   ]
 
@@ -77,7 +77,7 @@ signing key:
 
   urlpatterns = [
       ...
-      url(r'^api/token/verify/$', TokenVerifyView.as_view(), name='token_verify'),
+      path('api/token/verify/', TokenVerifyView.as_view(), name='token_verify'),
       ...
   ]
 
@@ -361,8 +361,8 @@ access token specific ``TokenObtainPairView`` and ``TokenRefreshView`` views:
 
   urlpatterns = [
       ...
-      url(r'^api/token/$', TokenObtainSlidingView.as_view(), name='token_obtain'),
-      url(r'^api/token/refresh/$', TokenRefreshSlidingView.as_view(), name='token_refresh'),
+      path('api/token/', TokenObtainSlidingView.as_view(), name='token_obtain'),
+      path('api/token/refresh/', TokenRefreshSlidingView.as_view(), name='token_refresh'),
       ...
   ]
 


### PR DESCRIPTION
When using Django latest version (2.1.7 at the moment), documentation about DRF_simplejwt usage is not correct, because the URL dispatcher syntax has changed. (See https://docs.djangoproject.com/en/2.1/topics/http/urls/)
This is a tiny update of the README file to make it work.
