### PR TITLE
Authenticate method should not return None if token is valid

### DIFF
--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -38,7 +38,7 @@ class JWTAuthentication(authentication.BaseAuthentication):
 
         validated_token = self.get_validated_token(raw_token)
 
-        return self.get_user(validated_token), raw_token
+        return self.get_user(validated_token), validated_token
 
     def authenticate_header(self, request):
         return '{0} realm="{1}"'.format(

--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -38,7 +38,7 @@ class JWTAuthentication(authentication.BaseAuthentication):
 
         validated_token = self.get_validated_token(raw_token)
 
-        return self.get_user(validated_token), None
+        return self.get_user(validated_token), raw_token
 
     def authenticate_header(self, request):
         return '{0} realm="{1}"'.format(


### PR DESCRIPTION
If token is valid and the user has been authenticated, the method "authenticate" should return a tuple with the user as first element (this is ok) and some authentication infos as second element. 

The tuple is used by DRF to populate request.user and request.auth:
https://www.django-rest-framework.org/api-guide/authentication/#authentication

Now, request.auth is always empty, even when authentication was succesful