### PR TITLE
Permit to use custom header name instead of "Authorization"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,7 @@ Some of Simple JWT's behavior can be customized through settings variables in
       'SIGNING_KEY': settings.SECRET_KEY,
       'VERIFYING_KEY': None,
 
+      'AUTH_HEADER_NAME': 'Authorization',
       'AUTH_HEADER_TYPES': ('Bearer',),
       'USER_ID_FIELD': 'id',
       'USER_ID_CLAIM': 'user_id',
@@ -222,6 +223,14 @@ VERIFYING_KEY
   ``SIGNING_KEY`` setting will be used.  If an RSA algorithm has been specified
   by the ``ALGORITHM`` setting, the ``VERIFYING_KEY`` setting must be set to a
   string which contains an RSA public key.
+
+AUTH_HEADER_NAME
+  Name of the header used to get authentication token. For example, a value of
+  ``Authorization`` means that the client will send its ``JWT`` token in a
+  header named ``Authorization``. This option permit to specify another token
+  name that the standard in case of conflict with another authentication system
+  which use the ``Authorization`` token too. Note: HTTP headers are
+  case-insensitive.
 
 AUTH_HEADER_TYPES
   The authorization header type(s) that will be accepted for views that require

--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -7,6 +7,7 @@ from .settings import api_settings
 from .state import User
 
 AUTH_HEADER_TYPES = api_settings.AUTH_HEADER_TYPES
+AUTH_HEADER_NAME = api_settings.AUTH_HEADER_NAME
 
 if not isinstance(api_settings.AUTH_HEADER_TYPES, (list, tuple)):
     AUTH_HEADER_TYPES = (AUTH_HEADER_TYPES,)
@@ -48,7 +49,7 @@ class JWTAuthentication(authentication.BaseAuthentication):
         Extracts the header containing the JSON web token from the given
         request.
         """
-        header = request.META.get('HTTP_AUTHORIZATION')
+        header = request.META.get('HTTP_{0}'.format(AUTH_HEADER_NAME.upper()))
 
         if isinstance(header, str):
             # Work around django test client oddness

--- a/rest_framework_simplejwt/settings.py
+++ b/rest_framework_simplejwt/settings.py
@@ -19,6 +19,7 @@ DEFAULTS = {
     'SIGNING_KEY': settings.SECRET_KEY,
     'VERIFYING_KEY': None,
 
+    'AUTH_HEADER_NAME': 'Authorization',
     'AUTH_HEADER_TYPES': ('Bearer',),
     'USER_ID_FIELD': 'id',
     'USER_ID_CLAIM': 'user_id',

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -40,6 +40,20 @@ class TestJWTAuthentication(TestCase):
         request = self.factory.get('/test-url/', HTTP_AUTHORIZATION=self.fake_header.decode('utf-8'))
         self.assertEqual(self.backend.get_header(request), self.fake_header)
 
+    def test_get_custom_named_header(self):
+
+        # override authorization header name
+        with override_api_settings(AUTH_HEADER_NAME='X-Authorization'):
+
+            # Should return None if no authorization header with custom name specified in settings
+            # event if a "Authorization" header is given
+            request = self.factory.get('/test-url/', HTTP_AUTHORIZATION=self.fake_header)
+            self.assertIsNone(self.backend.get_header(request))
+
+            # Should pull correct header off request
+            request = self.factory.get('/test-url/', HTTP_X_AUTHORIZATION=self.fake_header)
+            self.assertEqual(self.backend.get_header(request), self.fake_header)
+
     def test_get_raw_token(self):
         # Should return None if header lacks correct type keyword
         with override_api_settings(AUTH_HEADER_TYPES='JWT'):

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -43,7 +43,9 @@ class TestJWTAuthentication(TestCase):
     def test_get_custom_named_header(self):
 
         # override authorization header name
-        with override_api_settings(AUTH_HEADER_NAME='X-Authorization'):
+        with override_api_settings(AUTH_HEADER_NAME='CustomAuthorization'):
+
+            reload(authentication)
 
             # Should return None if no authorization header with custom name specified in settings
             # event if a "Authorization" header is given
@@ -51,8 +53,10 @@ class TestJWTAuthentication(TestCase):
             self.assertIsNone(self.backend.get_header(request))
 
             # Should pull correct header off request
-            request = self.factory.get('/test-url/', HTTP_X_AUTHORIZATION=self.fake_header)
+            request = self.factory.get('/test-url/', HTTP_CUSTOMAUTHORIZATION=self.fake_header)
             self.assertEqual(self.backend.get_header(request), self.fake_header)
+
+        reload(authentication)
 
     def test_get_raw_token(self):
         # Should return None if header lacks correct type keyword

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -27,6 +27,10 @@ class TestJWTAuthentication(TestCase):
         self.fake_token = b'TokenMcTokenface'
         self.fake_header = b'Bearer ' + self.fake_token
 
+    def tearDown(self):
+        # reload configuration after each test
+        reload(authentication)
+
     def test_get_header(self):
         # Should return None if no authorization header
         request = self.factory.get('/test-url/')
@@ -55,8 +59,6 @@ class TestJWTAuthentication(TestCase):
             # Should pull correct header off request
             request = self.factory.get('/test-url/', HTTP_CUSTOMAUTHORIZATION=self.fake_header)
             self.assertEqual(self.backend.get_header(request), self.fake_header)
-
-        reload(authentication)
 
     def test_get_raw_token(self):
         # Should return None if header lacks correct type keyword


### PR DESCRIPTION
Fix issue #99 

* documentation added in `README.md`
* test added