### PR TITLE
Add option to check_exp() for return result

### DIFF
--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -134,7 +134,7 @@ class Token:
 
         self.payload[claim] = datetime_to_epoch(from_time + lifetime)
 
-    def check_exp(self, claim='exp', current_time=None):
+    def check_exp(self, claim='exp', current_time=None, return_result=False):
         """
         Checks whether a timestamp value in the given claim has passed (since
         the given datetime value in `current_time`).  Raises a TokenError with
@@ -150,7 +150,10 @@ class Token:
 
         claim_time = datetime_from_epoch(claim_value)
         if claim_time <= current_time:
-            raise TokenError(format_lazy(_("Token '{}' claim has expired"), claim))
+            if return_result is True:
+                return True
+            else:
+                raise TokenError(format_lazy(_("Token '{}' claim has expired"), claim))
 
     @classmethod
     def for_user(cls, user):


### PR DESCRIPTION
Hi,

I'm developing making invitation url and verification by using django-rest-framework-simplejwt.

For simple check only expire time, I added option to check_exp() for return result.

Example of return version of check_exp() is as below.

```
# for only check expire time, skip other verification
access_token = AccessToken(token=access_token, verify=False)

# check whether expired or not by return value
expired = access_token.check_exp(return_result=True)
 
if expired is True:
    # responde message to client that invitation url has been expired

```

Thanks.