### PR TITLE
Ensure TokenBackend.encode() does not mutate payload

### DIFF
--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -33,12 +33,13 @@ class TokenBackend:
         """
         Returns an encoded token for the given payload dictionary.
         """
+        jwt_payload = payload.copy()
         if self.audience is not None:
-            payload['aud'] = self.audience
+            jwt_payload['aud'] = self.audience
         if self.issuer is not None:
-            payload['iss'] = self.issuer
+            jwt_payload['iss'] = self.issuer
 
-        token = jwt.encode(payload, self.signing_key, algorithm=self.algorithm)
+        token = jwt.encode(jwt_payload, self.signing_key, algorithm=self.algorithm)
         return token.decode('utf-8')
 
     def decode(self, token, verify=True):

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -102,9 +102,13 @@ class TestTokenBackend(TestCase):
 
     def test_encode_aud_iss(self):
         # Should return a JSON web token for the given payload
-        payload = {'exp': make_utc(datetime(year=2000, month=1, day=1))}
+        original_payload = {'exp': make_utc(datetime(year=2000, month=1, day=1))}
+        payload = original_payload.copy()
 
         rsa_token = self.aud_iss_token_backend.encode(payload)
+
+        # Assert that payload has not been mutated by the encode() function
+        self.assertEqual(payload, original_payload)
 
         # Token could be one of 12 depending on header dict ordering
         self.assertIn(


### PR DESCRIPTION
In reference to the issue outlined in: https://github.com/davesque/django-rest-framework-simplejwt/pull/62#discussion_r326329105

This PR ensures that the aud/iss support for token generation does not mutate the original payload passed to the `TokenBackend.encode()` method.