### PR TITLE
Allow TokenUser class to be configurable

### DIFF
--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -129,4 +129,4 @@ class JWTTokenUserAuthentication(JWTAuthentication):
             # identifier claim.
             raise InvalidToken(_('Token contained no recognizable user identification'))
 
-        return TokenUser(validated_token)
+        return api_settings.TOKEN_USER_CLASS(validated_token)

--- a/rest_framework_simplejwt/settings.py
+++ b/rest_framework_simplejwt/settings.py
@@ -29,6 +29,7 @@ DEFAULTS = {
     'TOKEN_TYPE_CLAIM': 'token_type',
 
     'JTI_CLAIM': 'jti',
+    'TOKEN_USER_CLASS': 'rest_framework_simplejwt.models.TokenUser',
 
     'SLIDING_TOKEN_REFRESH_EXP_CLAIM': 'refresh_exp',
     'SLIDING_TOKEN_LIFETIME': timedelta(minutes=5),
@@ -37,6 +38,7 @@ DEFAULTS = {
 
 IMPORT_STRINGS = (
     'AUTH_TOKEN_CLASSES',
+    'TOKEN_USER_CLASS',
 )
 
 REMOVED_SETTINGS = (

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -157,3 +157,25 @@ class TestJWTTokenUserAuthentication(TestCase):
 
         self.assertIsInstance(user, TokenUser)
         self.assertEqual(user.id, 42)
+
+    def test_custom_tokenuser(self):
+        from django.utils.functional import cached_property
+
+        class BobSaget(TokenUser):
+            @cached_property
+            def username(self):
+                return "bsaget"
+
+        temp = api_settings.TOKEN_USER_CLASS
+        api_settings.TOKEN_USER_CLASS = BobSaget
+
+        # Should return a token user object
+        payload = {api_settings.USER_ID_CLAIM: 42}
+        user = self.backend.get_user(payload)
+
+        self.assertIsInstance(user, api_settings.TOKEN_USER_CLASS)
+        self.assertEqual(user.id, 42)
+        self.assertEqual(user.username, "bsaget")
+
+        # Restore default TokenUser for future tests
+        api_settings.TOKEN_USER_CLASS = temp


### PR DESCRIPTION
Addresses #171 , adding a setting `TOKEN_USER_CLASS`, that can be used to override the default TokenUser. Added a unit test to ensure that this works, and there's an existing assertion that the default TokenUser class is preserved in `TestJWTTokenUserAuthentication.test_get_user`.