### PR TITLE
Resolve index max length issue less mysql5.7 with utf8mb4

### DIFF
--- a/rest_framework_simplejwt/token_blacklist/migrations/0004_auto_20171017_2013.py
+++ b/rest_framework_simplejwt/token_blacklist/migrations/0004_auto_20171017_2013.py
@@ -1,13 +1,29 @@
 from django.db import migrations, models
 
 
-class Migration(migrations.Migration):
+def is_vendor_less_than_mysql_innodb_56():
+    from django.db import connection
+    cursor = connection.cursor()
+    cursor.execute('SHOW VARIABLES LIKE "innodb_version"')
 
+    mysql_version = cursor.fetchone()
+
+    return mysql_version and mysql_version[1] < '5.7.0'
+
+
+class Migration(migrations.Migration):
     dependencies = [
         ('token_blacklist', '0003_auto_20171017_2007'),
     ]
 
     operations = [
+        migrations.AlterField(
+            model_name='outstandingtoken',
+            name='jti_hex',
+            field=models.CharField(unique=True, max_length=191),
+        )
+        if is_vendor_less_than_mysql_innodb_56()
+        else
         migrations.AlterField(
             model_name='outstandingtoken',
             name='jti_hex',

--- a/rest_framework_simplejwt/token_blacklist/models.py
+++ b/rest_framework_simplejwt/token_blacklist/models.py
@@ -5,6 +5,8 @@ from django.db import models
 class OutstandingToken(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, null=True, blank=True)
 
+    # notice: jti max_length is 191, when vendor is mysql innodb and version is less than 5.7
+    # caused by issue "Specified key was too long; max key length is 767 bytes"
     jti = models.CharField(unique=True, max_length=255)
     token = models.TextField()
 


### PR DESCRIPTION
when we use mysql less than 5.7 , 
below issue is occurred

~~~Python
query = b'ALTER TABLE `token_blacklist_outstandingtoken` ADD CONSTRAINT `token_blacklist_outstandingtoken_jti_hex_d9bdf6f7_uniq` UNIQUE (`jti_hex`)'

    def query(self, query):
        # Since _mysql releases GIL while querying, we need immutable buffer.
        if isinstance(query, bytearray):
            query = bytes(query)
>       _mysql.connection.query(self, query)
E       django.db.utils.OperationalError: (1071, 'Specified key was too long; max key length is 767 bytes')

~~~

#### similar issue
https://stackoverflow.com/questions/1814532/1071-specified-key-was-too-long-max-key-length-is-767-bytes

---
##### when 

~~~Python
# issue is occurred to max_length  from 192 to 256 more than,
jti_hex = models.CharField(unique=True, max_length=191)
~~~
`max-key-length-is-767-bytes` issue  is not occurred 

#### so i modify jti_hex's max_length  when database is mysql(inno_db) less than 5.7

---

#### this is sample docker-compose.yml to mysql5.6 

~~~~Docker

version: "3.3"
services:
  db:
    image: "mysql:5.6"
    restart: unless-stopped
  
    command: [
      'mysqld',
      '--character-set-server=utf8mb4',
      '--collation-server=utf8mb4_unicode_ci',
    ]
    environment:
      MYSQL_DATABASE: "test_database"
      MYSQL_USER: "test_user"
      MYSQL_PASSWORD: "test_password"
      MYSQL_ROOT_PASSWORD: "password"
    ports:
      - 3306:3306

