### PR TITLE
Fix pip install package name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Installation
 
 Simple JWT can be installed with pip::
 
-  pip install djangorestframework_simplejwt
+  pip install djangorestframework-simplejwt
 
 Then, your django project must be configured to use the library.  In
 ``settings.py``, add


### PR DESCRIPTION
The package name is `djangorestframework-simplejwt` with a hyphen instead of an underscore.