### PR TITLE
Fix lint error: Remove unused TokenUser import

### DIFF
--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -2,7 +2,6 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import HTTP_HEADER_ENCODING, authentication
 
 from .exceptions import AuthenticationFailed, InvalidToken, TokenError
-from .models import TokenUser
 from .settings import api_settings
 from .state import User
 


### PR DESCRIPTION
Simply removes an unused import that's triggering a lint failure.

Sorry I missed this in #172 , I obviously did not lint my branch.